### PR TITLE
bug fix for blob path

### DIFF
--- a/CustomSkillForDataIngestion/QnAIntegrationCustomSkill/Lookup.cs
+++ b/CustomSkillForDataIngestion/QnAIntegrationCustomSkill/Lookup.cs
@@ -11,11 +11,9 @@ using Common;
 using Azure;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Models;
-using Azure.Storage.Blobs;
 using Azure.Storage;
 using Azure.Storage.Sas;
 using System.Net;
-using Microsoft.Azure.Storage.Auth;
 
 namespace QnAIntegrationCustomSkill
 {
@@ -52,14 +50,19 @@ namespace QnAIntegrationCustomSkill
             var response = await searchClient.GetDocumentAsync<SearchDocument>(id);
 
 
-            object metadata_storage_name;
-            response.Value.TryGetValue("metadata_storage_name", out metadata_storage_name);
+            object metadata_storage_path;
+            response.Value.TryGetValue("metadata_storage_path", out metadata_storage_path);
+            var storagePath = metadata_storage_path.ToString();
+            var startIndex = storagePath.IndexOf(Constants.containerName) + Constants.containerName.Length + 1;
+            var blobName = storagePath.Substring(startIndex);
+            blobName = Uri.UnescapeDataString(blobName);
+            log.LogInformation(blobName);
 
             var policy = new BlobSasBuilder
             {
                 Protocol = SasProtocol.HttpsAndHttp,
                 BlobContainerName = storageContainerName,
-                BlobName = metadata_storage_name.ToString(),
+                BlobName = blobName,
                 Resource = "b",
                 StartsOn = DateTimeOffset.UtcNow,
                 ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),

--- a/CustomSkillForDataIngestion/QnAIntegrationCustomSkill/Search.cs
+++ b/CustomSkillForDataIngestion/QnAIntegrationCustomSkill/Search.cs
@@ -127,7 +127,7 @@ namespace QnAIntegrationCustomSkill
                 output.answers = new QnAResult();
                 output.answers.answer = qnaResponse.Answers.First();
                 var source = output.answers.answer.Source;
-                output.answers.document = await GetDocument(source, output.results);
+                output.answers.document = await GetDocument(source, output.results, log);
             }
 
             return new OkObjectResult(output);
@@ -247,20 +247,22 @@ namespace QnAIntegrationCustomSkill
             return runtimeKey;
         }
 
-        private static async Task<SearchResult<SearchDocument>> GetDocument(string source, List<SearchResult<SearchDocument>> searchResult)
+        private static async Task<SearchResult<SearchDocument>> GetDocument(string source, List<SearchResult<SearchDocument>> searchResult, ILogger log)
         {
             if (source == null)
             {
                 return null;
             }
-
+            
             var blobURL = string.Concat(blobBaseURL, source);
+            log.LogInformation(blobURL);
             // check if source present in search results 
             foreach (var doc in searchResult)
             {
                 object name;
                 if (doc.Document.TryGetValue("metadata_storage_path", out name) && name.ToString() == blobURL)
                 {
+                    log.LogInformation("blob path constructed: " + blobURL + " blob path in index: " + name.ToString());
                     return doc;
                 }
             }
@@ -268,7 +270,7 @@ namespace QnAIntegrationCustomSkill
             // else query search index
             SearchOptions options = new SearchOptions();
             options.SearchFields.Add("metadata_storage_path");
-            var result = await searchClient.SearchAsync<SearchDocument>(blobURL, options);
+            var result = await searchClient.SearchAsync<SearchDocument>("\""+blobURL+"\"", options);
             return result.Value.GetResults().ToList().First();
         }
     }


### PR DESCRIPTION
- set the escaped path (folder1/folder2/.../filename) as the source in qna maker
- use blob path to get sas for document, works for blobs in folders as well in lookup.cs
- use exact match for querying qna-idx in search.cs